### PR TITLE
fix: update Dockerfile base image to fix vuln

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-rc-alpine
+FROM python:3.11-rc-alpine3.16
 
 LABEL "com.github.actions.name"="GitHub Action for pylint"
 LABEL "com.github.actions.description"="Run pylint commands"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /build
 COPY .pylintrc /build/.pylintrc
 
 RUN apk add py3-pip && apk add git
+RUN apk upgrade --available && sync
 RUN pip3 install -U setuptools
 RUN pip3 install -U pylint
 RUN pip3 install -U pylint-exit


### PR DESCRIPTION
Updating the base image due to Snyk reported vuln. 

```Testing edmerrett/pylint-action...

✗ Low severity vulnerability found in curl/libcurl
  Description: CVE-2022-35252
  Info: https://snyk.io/vuln/SNYK-ALPINE316-CURL-3011748
  Introduced through: curl/libcurl@7.83.1-r2, git/git@2.36.2-r0
  From: curl/libcurl@7.83.1-r2
  From: git/git@2.36.2-r0 > curl/libcurl@7.83.1-r2
  Image layer: 'apk add git'
  Fixed in: 7.83.1-r3

✗ Critical severity vulnerability found in expat/expat
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-ALPINE316-EXPAT-3028183
  Introduced through: expat/expat@2.4.8-r0, .python-rundeps@20220812.022714, git/git@2.36.2-r0, python3/python3@3.10.5-r0
  From: expat/expat@2.4.8-r0
  From: .python-rundeps@20220812.022714 > expat/expat@2.4.8-r0
  From: git/git@2.36.2-r0 > expat/expat@2.4.8-r0
  and 1 more...
  Image layer: 'apk add git'
  Fixed in: 2.4.9-r0



Organization:      edmerrett
Package manager:   apk
Project name:      docker-image|edmerrett/pylint-action
Docker image:      edmerrett/pylint-action
Platform:          linux/amd64
Base image:        python:3.11.0rc1-alpine3.16
Licenses:          enabled

Tested 58 dependencies for known issues, found 2 issues.

According to our scan, you are currently using the most secure version of the selected base image```